### PR TITLE
feat(rmcp): add support for custom notifications

### DIFF
--- a/crates/rmcp/src/handler/client.rs
+++ b/crates/rmcp/src/handler/client.rs
@@ -56,6 +56,9 @@ impl<H: ClientHandler> Service<RoleClient> for H {
             ServerNotification::PromptListChangedNotification(_notification_no_param) => {
                 self.on_prompt_list_changed(context).await
             }
+            ServerNotification::CustomNotification(notification) => {
+                self.on_custom_notification(notification.method, notification.params, context).await
+            }
         };
         Ok(())
     }
@@ -162,6 +165,14 @@ pub trait ClientHandler: Sized + Send + Sync + 'static {
     }
     fn on_prompt_list_changed(
         &self,
+        context: NotificationContext<RoleClient>,
+    ) -> impl Future<Output = ()> + Send + '_ {
+        std::future::ready(())
+    }
+    fn on_custom_notification(
+        &self,
+        method: String,
+        params: serde_json::Value,
         context: NotificationContext<RoleClient>,
     ) -> impl Future<Output = ()> + Send + '_ {
         std::future::ready(())

--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -89,6 +89,9 @@ impl<H: ServerHandler> Service<RoleServer> for H {
             ClientNotification::RootsListChangedNotification(_notification) => {
                 self.on_roots_list_changed(context).await
             }
+            ClientNotification::CustomNotification(notification) => {
+                self.on_custom_notification(notification.method, notification.params, context).await
+            }
         };
         Ok(())
     }
@@ -220,6 +223,14 @@ pub trait ServerHandler: Sized + Send + Sync + 'static {
     }
     fn on_roots_list_changed(
         &self,
+        context: NotificationContext<RoleServer>,
+    ) -> impl Future<Output = ()> + Send + '_ {
+        std::future::ready(())
+    }
+    fn on_custom_notification(
+        &self,
+        method: String,
+        params: serde_json::Value,
         context: NotificationContext<RoleServer>,
     ) -> impl Future<Output = ()> + Send + '_ {
         std::future::ready(())

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1637,6 +1637,13 @@ pub struct GetPromptResult {
 }
 
 // =============================================================================
+// CUSTOM NOTIFICATIONS
+// =============================================================================
+
+/// Custom notification for protocol extensions beyond standard MCP
+pub type CustomNotification = Notification<String, serde_json::Value>;
+
+// =============================================================================
 // MESSAGE TYPE UNIONS
 // =============================================================================
 
@@ -1730,7 +1737,8 @@ ts_union!(
     | CancelledNotification
     | ProgressNotification
     | InitializedNotification
-    | RootsListChangedNotification;
+    | RootsListChangedNotification
+    | CustomNotification;
 );
 
 ts_union!(
@@ -1761,7 +1769,8 @@ ts_union!(
     | ResourceUpdatedNotification
     | ResourceListChangedNotification
     | ToolListChangedNotification
-    | PromptListChangedNotification;
+    | PromptListChangedNotification
+    | CustomNotification;
 );
 
 ts_union!(

--- a/crates/rmcp/src/model/meta.rs
+++ b/crates/rmcp/src/model/meta.rs
@@ -84,6 +84,7 @@ variant_extension! {
         ProgressNotification
         InitializedNotification
         RootsListChangedNotification
+        CustomNotification
     }
 }
 
@@ -96,6 +97,7 @@ variant_extension! {
         ResourceListChangedNotification
         ToolListChangedNotification
         PromptListChangedNotification
+        CustomNotification
     }
 }
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]

--- a/crates/rmcp/src/service/client.rs
+++ b/crates/rmcp/src/service/client.rs
@@ -359,6 +359,21 @@ impl Peer<RoleClient> {
     method!(peer_not notify_progress ProgressNotification(ProgressNotificationParam));
     method!(peer_not notify_initialized InitializedNotification);
     method!(peer_not notify_roots_list_changed RootsListChangedNotification);
+
+    pub async fn send_custom_notification(
+        &self,
+        method: String,
+        params: serde_json::Value,
+    ) -> Result<(), ServiceError> {
+        self.send_notification(ClientNotification::CustomNotification(
+            crate::model::Notification {
+                method,
+                params,
+                extensions: Default::default(),
+            }
+        ))
+        .await
+    }
 }
 
 impl Peer<RoleClient> {

--- a/crates/rmcp/src/service/server.rs
+++ b/crates/rmcp/src/service/server.rs
@@ -413,6 +413,21 @@ impl Peer<RoleServer> {
     method!(peer_not notify_resource_list_changed ResourceListChangedNotification);
     method!(peer_not notify_tool_list_changed ToolListChangedNotification);
     method!(peer_not notify_prompt_list_changed PromptListChangedNotification);
+
+    pub async fn send_custom_notification(
+        &self,
+        method: String,
+        params: serde_json::Value,
+    ) -> Result<(), ServiceError> {
+        self.send_notification(ServerNotification::CustomNotification(
+            crate::model::Notification {
+                method,
+                params,
+                extensions: Default::default(),
+            }
+        ))
+        .await
+    }
 }
 
 // =============================================================================

--- a/examples/clients/Cargo.toml
+++ b/examples/clients/Cargo.toml
@@ -51,6 +51,10 @@ name = "clients_collection"
 path = "src/collection.rs"
 
 [[example]]
+name = "clients_custom_notification"
+path = "src/custom_notification.rs"
+
+[[example]]
 name = "clients_oauth_client"
 path = "src/auth/oauth_client.rs"
 

--- a/examples/clients/src/custom_notification.rs
+++ b/examples/clients/src/custom_notification.rs
@@ -1,0 +1,159 @@
+use anyhow::Result;
+use rmcp::{
+    ClientHandler, ServerHandler, ServiceExt,
+    model::*,
+    service::{NotificationContext, RoleClient, RoleServer},
+};
+use serde_json::json;
+use tokio::sync::mpsc;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+pub struct TestServer {
+    notification_tx: mpsc::UnboundedSender<(String, serde_json::Value)>,
+}
+
+impl ServerHandler for TestServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::LATEST,
+            server_info: Implementation {
+                name: "test-server".to_string(),
+                version: "1.0.0".to_string(),
+                title: None,
+                icons: None,
+                website_url: None,
+            },
+            capabilities: ServerCapabilities::default(),
+            instructions: None,
+        }
+    }
+
+    fn on_custom_notification(
+        &self,
+        method: String,
+        params: serde_json::Value,
+        _context: NotificationContext<RoleServer>,
+    ) -> impl std::future::Future<Output = ()> + Send + '_ {
+        tracing::info!("Server received custom notification: method={method}, params={params:#?}");
+        self.notification_tx.send((method, params)).ok();
+        std::future::ready(())
+    }
+}
+
+pub struct TestClient {
+    notification_rx: mpsc::UnboundedSender<(String, serde_json::Value)>,
+}
+
+impl ClientHandler for TestClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo {
+            protocol_version: ProtocolVersion::LATEST,
+            capabilities: ClientCapabilities::default(),
+            client_info: Implementation {
+                name: "test-client".to_string(),
+                version: "1.0.0".to_string(),
+                title: None,
+                icons: None,
+                website_url: None,
+            },
+        }
+    }
+
+    fn on_custom_notification(
+        &self,
+        method: String,
+        params: serde_json::Value,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl std::future::Future<Output = ()> + Send + '_ {
+        tracing::info!("Client received custom notification: method={method}, params={params:#?}");
+        self.notification_rx.send((method, params)).ok();
+        std::future::ready(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| format!("info,{}=debug", env!("CARGO_CRATE_NAME")).into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let (server_tx, mut server_rx) = mpsc::unbounded_channel();
+    let (client_tx, mut client_rx) = mpsc::unbounded_channel();
+
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+
+    let server = TestServer {
+        notification_tx: server_tx,
+    };
+
+    let server_handle = tokio::spawn(async move {
+        let service = server.serve(server_transport).await?;
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        tracing::info!("Server sending custom notification to client");
+        service.peer().send_custom_notification(
+            "notifications/session/update".to_string(),
+            json!({
+                "sessionId": "test-session-123",
+                "messageId": "msg-456",
+                "progress": "delta",
+                "content": [{
+                    "type": "text",
+                    "text": "Hello from server!"
+                }]
+            })
+        ).await?;
+
+        if let Some((method, params)) = server_rx.recv().await {
+            tracing::info!("Server verifying client notification: method={method}");
+            assert_eq!(method, "client/status/update");
+            assert_eq!(params["status"], "ready");
+        }
+
+        service.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient {
+        notification_rx: client_tx,
+    };
+
+    let client_service = client.serve(client_transport).await?;
+
+    tracing::info!("Starting bidirectional custom notification test");
+
+    tokio::select! {
+        Some((method, params)) = client_rx.recv() => {
+            tracing::info!("Client verifying server notification: method={method}");
+            assert_eq!(method, "notifications/session/update");
+            assert_eq!(params["sessionId"], "test-session-123");
+
+            tracing::info!("Client sending custom notification to server");
+            client_service.peer().send_custom_notification(
+                "client/status/update".to_string(),
+                json!({
+                    "clientId": "client-789",
+                    "status": "ready",
+                    "capabilities": ["streaming", "batch-processing"]
+                })
+            ).await?;
+        }
+        _ = tokio::time::sleep(tokio::time::Duration::from_secs(5)) => {
+            panic!("Timeout waiting for notification");
+        }
+    }
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    client_service.cancel().await?;
+    server_handle.await??;
+
+    tracing::info!("Bidirectional custom notification test completed successfully");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add bidirectional custom notification support to RMCP library for protocol extensions
- Enable clients and servers to exchange application-specific notifications beyond standard MCP types
- Support use cases like MCP-AX protocol which requires custom notifications for real-time session updates
- Maintain full backward compatibility with existing notification handlers

## Changes
- Added `CustomNotification` type alias in model.rs for dynamic notification methods
- Extended `ClientNotification` and `ServerNotification` enums to include CustomNotification variant
- Implemented `send_custom_notification()` methods on both `Peer<RoleClient>` and `Peer<RoleServer>`
- Added `on_custom_notification()` handler methods to ClientHandler and ServerHandler traits with default no-op implementations
- Updated variant_extension macro in meta.rs to support CustomNotification metadata handling
- Created comprehensive example demonstrating bidirectional custom notification exchange
- Modified Cargo.toml to register the new example

## Test Plan
- Run `cargo build --package rmcp` to verify successful compilation
- Run `cargo test --package rmcp` to ensure existing tests pass
- Execute the custom notification example: `cargo run --example custom_notification`
- Verify bidirectional communication works by checking log output shows both server-to-client and client-to-server notifications
- Confirm backward compatibility by running existing examples to ensure they still work without modifications