### PR TITLE
fix(rmcp): process notifications synchronously to preserve ordering

### DIFF
--- a/crates/rmcp/src/service.rs
+++ b/crates/rmcp/src/service.rs
@@ -782,7 +782,6 @@ where
                     notification,
                     ..
                 })) => {
-                    tracing::info!(?notification, "received notification");
                     // catch cancelled notification
                     let mut notification = match notification.try_into() {
                         Ok::<CancelledNotification, _>(cancelled) => {
@@ -806,13 +805,13 @@ where
                             meta,
                             extensions,
                         };
-                        let current_span = tracing::Span::current();
-                        tokio::spawn(async move {
-                            let result = service.handle_notification(notification, context).await;
-                            if let Err(error) = result {
-                                tracing::warn!(%error, "Error sending notification");
-                            }
-                        }.instrument(current_span));
+                        // Process notification synchronously to preserve ordering.
+                        // Spawning as separate tasks causes race conditions where
+                        // notifications can complete out of order.
+                        let result = service.handle_notification(notification, context).await;
+                        if let Err(error) = result {
+                            tracing::warn!(%error, "Error sending notification");
+                        }
                     }
                 }
                 Event::PeerMessage(JsonRpcMessage::Response(JsonRpcResponse {


### PR DESCRIPTION
## Summary

- Fix notification ordering issue that caused garbled streaming text during rapid LLM token streaming
- Remove tokio::spawn for notification handling to prevent race conditions
- Notifications are now processed inline within the event loop, preserving arrival order
- This ensures streaming text chunks appear in correct sequence (e.g., "Wanderer's" instead of "Wan'sderer")

The issue occurred because spawning each notification as a separate tokio task allowed the scheduler to execute them out of order when notifications arrived in rapid succession (milliseconds apart during LLM streaming). Since notification handlers typically just send to channels (non-blocking operations), synchronous processing has negligible performance impact.

## Changes

- Modified `crates/rmcp/src/service.rs` in the `serve_inner` function:
  - Removed `tokio::spawn` wrapper around notification handling
  - Removed `tracing::Span::current()` and `.instrument()` calls (no longer needed without spawn)
  - Removed verbose `tracing::info!(?notification, "received notification")` debug log
  - Added inline comment explaining why synchronous processing is necessary
  - Notification handler now called directly with `.await` in the event loop

## Test Plan

- Run `cargo build -p rmcp` to verify compilation
- Run `cargo test -p rmcp` to ensure existing tests pass
- Manual testing: Send rapid streaming notifications and verify text chunks arrive in correct order
- Verify no performance regression for typical notification workloads (channel sends are non-blocking)