### PR TITLE
feat(rmcp): add PR_SET_PDEATHSIG for child process cleanup on Linux

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -50,6 +50,10 @@ tower-service = { version = "0.3", optional = true }
 # for child process transport
 process-wrap = { version = "8.2", features = ["tokio1"], optional = true }
 
+# for PR_SET_PDEATHSIG on Linux (child process cleanup when parent dies)
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 # for ws transport
 # tokio-tungstenite ={ version = "0.26", optional = true }
 

--- a/crates/rmcp/src/transport/child_process.rs
+++ b/crates/rmcp/src/transport/child_process.rs
@@ -7,6 +7,9 @@ use tokio::{
     process::{ChildStderr, ChildStdin, ChildStdout},
 };
 
+#[cfg(target_os = "linux")]
+use std::os::unix::process::CommandExt;
+
 use super::{RxJsonRpcMessage, Transport, TxJsonRpcMessage, async_rw::AsyncRwTransport};
 use crate::RoleClient;
 
@@ -191,6 +194,18 @@ impl TokioChildProcessBuilder {
             .stdin(self.stdin)
             .stdout(self.stdout)
             .stderr(self.stderr);
+
+        // On Linux, request that the kernel sends SIGTERM to the child when the parent dies.
+        // This ensures MCP servers are cleaned up even if the agent is killed with SIGKILL.
+        #[cfg(target_os = "linux")]
+        unsafe {
+            self.cmd.command_mut().pre_exec(|| {
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
 
         let (child, stdout, stdin, stderr_opt) = child_process(self.cmd.spawn()?)?;
 


### PR DESCRIPTION
## Summary

- Add automatic child process cleanup on Linux when the parent process dies
- Use `prctl(PR_SET_PDEATHSIG, SIGTERM)` to request the kernel to send SIGTERM to child processes
- Handles the edge case where the agent is killed with SIGKILL, which would otherwise leave orphaned MCP server processes running
- Linux-specific implementation using `cfg(target_os = "linux")` with no impact on other platforms

## Changes

- Modified `crates/rmcp/Cargo.toml`:
  - Added `libc = "0.2"` as a Linux-only dependency using `[target.'cfg(target_os = "linux")'.dependencies]`
- Modified `crates/rmcp/src/transport/child_process.rs`:
  - Added conditional import for `std::os::unix::process::CommandExt` on Linux
  - Added `pre_exec` hook in `TokioChildProcessBuilder::spawn()` that calls `prctl(PR_SET_PDEATHSIG, SIGTERM)`
  - Includes proper error handling for the `prctl` syscall

## Test Plan

- Run `cargo build` to verify successful compilation on non-Linux platforms
- Run `cargo build --target x86_64-unknown-linux-gnu` (or on a Linux machine) to verify Linux compilation
- Run `cargo test` to ensure existing tests pass
- Manual verification on Linux:
  1. Start an MCP server via child process transport
  2. Kill the parent process with `kill -9`
  3. Verify the child MCP server process is also terminated