### PR TITLE
fix(rmcp): move deps before Linux target section and add set_metadata

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -50,10 +50,6 @@ tower-service = { version = "0.3", optional = true }
 # for child process transport
 process-wrap = { version = "8.2", features = ["tokio1"], optional = true }
 
-# for PR_SET_PDEATHSIG on Linux (child process cleanup when parent dies)
-[target.'cfg(target_os = "linux")'.dependencies]
-libc = "0.2"
-
 # for ws transport
 # tokio-tungstenite ={ version = "0.26", optional = true }
 
@@ -65,8 +61,14 @@ uuid = { version = "1", features = ["v4"], optional = true }
 http-body = { version = "1", optional = true }
 http-body-util = { version = "0.1", optional = true }
 bytes = { version = "1", optional = true }
+
 # macro
 rmcp-macros = { workspace = true, optional = true }
+
+# for PR_SET_PDEATHSIG on Linux (child process cleanup when parent dies)
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }
 

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -320,6 +320,15 @@ impl AuthorizationManager {
         Ok(())
     }
 
+    /// Set custom authorization metadata.
+    ///
+    /// Use this for OAuth servers that don't support standard metadata discovery
+    /// (e.g., servers without `/.well-known/oauth-authorization-server` endpoint).
+    /// This must be called before `configure_client()` or `configure_client_id()`.
+    pub fn set_metadata(&mut self, metadata: AuthorizationMetadata) {
+        self.metadata = Some(metadata);
+    }
+
     /// discover oauth2 metadata
     pub async fn discover_metadata(&self) -> Result<AuthorizationMetadata, AuthError> {
         if let Some(metadata) = self.try_discover_oauth_server(&self.base_url).await? {


### PR DESCRIPTION
## Summary

- Fix cross-platform build by correcting Cargo.toml dependency section ordering
- Add `set_metadata()` method to `AuthorizationManager` for custom OAuth configuration
- HTTP-server transport dependencies were accidentally gated to Linux-only due to TOML section placement
- Enables OAuth servers without standard discovery endpoints to be configured manually

## Changes

**crates/rmcp/Cargo.toml:**
- Moved http-server transport dependencies (axum, rand, tokio-stream, uuid, http-body, http-body-util, bytes, rmcp-macros) before the `[target.'cfg(target_os = "linux")'.dependencies]` section
- These dependencies were incorrectly placed after the Linux target section, causing them to only be included on Linux builds
- Relocated the Linux-specific `libc` dependency section to after all general dependencies

**crates/rmcp/src/transport/auth.rs:**
- Added `AuthorizationManager::set_metadata()` public method
- Allows manually setting OAuth authorization metadata for servers that don't support standard discovery (e.g., servers without `/.well-known/oauth-authorization-server` endpoint)
- Must be called before `configure_client()` or `configure_client_id()`

## Test Plan

- Run `cargo build -p rmcp --features "client,macros,schemars,reqwest,transport-streamable-http-client,transport-streamable-http-client-reqwest,transport-streamable-http-server,transport-child-process,transport-io,auth"` on macOS/Windows to verify cross-platform build works
- Verify `tokio-stream`, `rmcp-macros`, `bytes`, `http-body`, `http-body-util`, `rand`, and `uuid` are now compiled on non-Linux platforms
- Confirm `cargo tree -p rmcp` shows these dependencies in the tree on all platforms