### PR TITLE
feat(rmcp): support flexible authorization schemes in HTTP client

### DIFF
--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -39,7 +39,7 @@ impl StreamableHttpClient for reqwest::Client {
             request_builder = request_builder.header(HEADER_LAST_EVENT_ID, last_event_id);
         }
         if let Some(auth_header) = auth_token {
-            request_builder = request_builder.bearer_auth(auth_header);
+            request_builder = request_builder.header(reqwest::header::AUTHORIZATION, auth_header);
         }
         let response = request_builder.send().await?;
         if response.status() == reqwest::StatusCode::METHOD_NOT_ALLOWED {
@@ -72,7 +72,7 @@ impl StreamableHttpClient for reqwest::Client {
     ) -> Result<(), StreamableHttpError<Self::Error>> {
         let mut request_builder = self.delete(uri.as_ref());
         if let Some(auth_header) = auth_token {
-            request_builder = request_builder.bearer_auth(auth_header);
+            request_builder = request_builder.header(reqwest::header::AUTHORIZATION, auth_header);
         }
         let response = request_builder
             .header(HEADER_SESSION_ID, session.as_ref())
@@ -99,7 +99,7 @@ impl StreamableHttpClient for reqwest::Client {
             .post(uri.as_ref())
             .header(ACCEPT, [EVENT_STREAM_MIME_TYPE, JSON_MIME_TYPE].join(", "));
         if let Some(auth_header) = auth_token {
-            request = request.bearer_auth(auth_header);
+            request = request.header(reqwest::header::AUTHORIZATION, auth_header);
         }
         if let Some(session_id) = session_id {
             request = request.header(HEADER_SESSION_ID, session_id.as_ref());

--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -732,9 +732,9 @@ impl StreamableHttpClientTransportConfig {
     ///
     /// # Arguments
     ///
-    /// * `value` - A bearer token without the `Bearer ` prefix
+    /// * `value` - The full Authorization header value including the scheme
+    ///   (e.g., "Bearer token123", "Basic dXNlcjpwYXNz", "ApiKey xyz")
     pub fn auth_header<T: Into<String>>(mut self, value: T) -> Self {
-        // set our authorization header
         self.auth_header = Some(value.into());
         self
     }


### PR DESCRIPTION
PR Title: feat(rmcp): support flexible authorization schemes in HTTP client

## Summary

- Replace `bearer_auth()` with direct `Authorization` header setting in the streamable HTTP client
- Enable support for any authentication scheme (Bearer, Basic, ApiKey, custom schemes)
- Previously, only Bearer tokens were supported; now users can pass the full Authorization header value
- Improves flexibility for integrating with APIs that require non-Bearer authentication

## Changes

- Modified `crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs`:
  - Changed 3 occurrences of `bearer_auth(auth_header)` to `header(reqwest::header::AUTHORIZATION, auth_header)`
  - Affects `get_sse_stream()`, `delete_session()`, and `post_message()` methods
- Modified `crates/rmcp/src/transport/streamable_http_client.rs`:
  - Updated documentation for `auth_header()` method to clarify it now accepts the full Authorization header value including the scheme prefix (e.g., "Bearer token123", "Basic dXNlcjpwYXNz", "ApiKey xyz")

## Test Plan

- Run `cargo build -p rmcp` to verify successful compilation
- Run `cargo test -p rmcp` to ensure existing tests pass
- Verify streamable HTTP client examples compile: `cargo build --examples -p rmcp`
- Manual testing: configure an MCP server with different auth schemes (Bearer, Basic, ApiKey) and verify connections work correctly
