### PR TITLE
fix(rmcp): add Bearer prefix for OAuth tokens in AuthClient

### DIFF
--- a/crates/rmcp/src/transport/common/auth/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/auth/streamable_http_client.rs
@@ -16,7 +16,8 @@ where
     ) -> Result<(), crate::transport::streamable_http_client::StreamableHttpError<Self::Error>>
     {
         if auth_token.is_none() {
-            auth_token = Some(self.get_access_token().await?);
+            // OAuth tokens need "Bearer " prefix for the Authorization header
+            auth_token = Some(format!("Bearer {}", self.get_access_token().await?));
         }
         self.http_client
             .delete_session(uri, session_id, auth_token)
@@ -34,7 +35,8 @@ where
         crate::transport::streamable_http_client::StreamableHttpError<Self::Error>,
     > {
         if auth_token.is_none() {
-            auth_token = Some(self.get_access_token().await?);
+            // OAuth tokens need "Bearer " prefix for the Authorization header
+            auth_token = Some(format!("Bearer {}", self.get_access_token().await?));
         }
         self.http_client
             .get_stream(uri, session_id, last_event_id, auth_token)
@@ -52,7 +54,8 @@ where
         StreamableHttpError<Self::Error>,
     > {
         if auth_token.is_none() {
-            auth_token = Some(self.get_access_token().await?);
+            // OAuth tokens need "Bearer " prefix for the Authorization header
+            auth_token = Some(format!("Bearer {}", self.get_access_token().await?));
         }
         self.http_client
             .post_message(uri, message, session_id, auth_token)


### PR DESCRIPTION
## Summary
- Fix OAuth tokens being sent without "Bearer " prefix after the flexible auth scheme change
- The previous commit changed from `bearer_auth()` to `header(AUTHORIZATION, ...)` to support non-bearer schemes like ApiKey
- However, AuthClient.get_access_token() returns just the raw token, so OAuth requests were sent without the required "Bearer " prefix

## Changes
- **crates/rmcp/src/transport/common/auth/streamable_http_client.rs**: Modified all three methods (`delete_session`, `get_stream`, `post_message`) to prefix OAuth tokens with "Bearer " when calling `get_access_token()`

## Test Plan
- Verify OAuth-based MCP servers can authenticate successfully
- Verify non-OAuth auth schemes (ApiKey, Basic) still work via direct `auth_header` config